### PR TITLE
Change fs system to reify fs plugins instead of default to file fs

### DIFF
--- a/src/drake/fs.clj
+++ b/src/drake/fs.clj
@@ -434,7 +434,9 @@
   (let [[prefix filename] (split-path path)
         filesystem (FILESYSTEMS prefix)]
     (if (nil? filesystem)
-      [(FILESYSTEMS "file") "file" path]
+      (let [fs (plugins/get-reified "drake.fs." prefix)]
+        (if fs [fs prefix filename] [(FILESYSTEMS "file") "file" path])
+      )
       [filesystem prefix filename])))
 
 (defn fs


### PR DESCRIPTION
This resolves the bug https://github.com/Factual/drake/issues/111 in that it makes the sample Filesystem work with only a trivial modification (see my other pull request against drake-echostep). 

I taught myself clojure to make this diff so I wouldn't blindly merge. Note that there are some specification related concerns here (should FS's have to deal with leading slashes and why is it "hdfs://" when it is "mock:/") that this diff does not address. 
