### PR TITLE
make variable substitution work in command substitution

### DIFF
--- a/resources/regtest/regtest_command_substitution.sh
+++ b/resources/regtest/regtest_command_substitution.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Regression testing for Drake: variable string substitution inside a command substitution
+# Relevant URLs:
+# https://github.com/Factual/drake/issues/129
+
+source $(dirname $0)/regtest_utils.sh
+
+cleanup() {
+  rm -f test_variable.out
+}
+
+echo "----------------------------"
+echo "TESTS: variable substitution"
+echo "----------------------------"
+
+cleanup
+run_d regtest_command_substitution_variable.d -a
+check "`cat test_variable.out`" '-world-/-world-/-$[VAR]-/-6-'
+
+# All tests passed
+echo "ALL PASSED"
+
+# Clean up again
+cleanup

--- a/resources/regtest/regtest_command_substitution_variable.d
+++ b/resources/regtest/regtest_command_substitution_variable.d
@@ -1,0 +1,8 @@
+VAR="world"
+TEXT1=$(echo -$[VAR]-)
+TEXT2=$(echo -"$[VAR]"-)
+TEXT3=$(echo -'$[VAR]'-)
+TEXT4=$(echo -"$(echo $[VAR] | wc -c)"-)
+
+test_variable.out <-
+    echo $TEXT1/$TEXT2/$TEXT3/$TEXT4 > $OUTPUT

--- a/resources/regtest/run-all.sh
+++ b/resources/regtest/run-all.sh
@@ -3,6 +3,7 @@ if ($(dirname $0)/regtest_fs.sh &&
     $(dirname $0)/regtest_stdout.sh &&
     $(dirname $0)/regtest_interpreters.sh &&
     $(dirname $0)/regtest_inline_shell.sh &&
+    $(dirname $0)/regtest_command_substitution.sh &&
     $(dirname $0)/regtest_async.sh &&
     $(dirname $0)/regtest_splitvars.sh &&
     $(dirname $0)/regtest_inputs_outputs.sh &&

--- a/src/drake/parser.clj
+++ b/src/drake/parser.clj
@@ -178,6 +178,13 @@
 
 (def shell-memo (memo/memo shell-helper))
 
+(def double-quote-shell-string
+  (p/semantics (p/conc double-quote
+                       (p/rep* (p/alt (var-sub true true)
+                                      non-double-quote-or-backslash double-quote-escaped-chars))
+                       double-quote)
+               flatten-apply-str))
+
 (def command-sub
   "input: shell cmd invocations of form $(...)
    output: output of the shell command with trailing line-breaks trimmed"
@@ -187,6 +194,7 @@
     prod (p/semantics
           (p/rep+ (p/alt single-quote-shell-string 
                          double-quote-shell-string
+                         (var-sub true true)
                          (p/except string-char close-paren)))
           apply-str)
     _ (p/failpoint close-paren

--- a/src/drake/parser_utils.clj
+++ b/src/drake/parser_utils.clj
@@ -151,7 +151,7 @@
 (def double-quote (nb-char-lit \"))
 (def backslash (nb-char-lit \\))
 (def backquote (nb-char-lit \`))
-(def doublequote-escaped-chars (p/conc backslash
+(def double-quote-escaped-chars (p/conc backslash
                                        (p/alt dollar-sign
                                               backquote
                                               double-quote
@@ -173,12 +173,6 @@
   (p/semantics (p/conc single-quote
                        (p/rep* non-single-quote)
                        single-quote)
-               flatten-apply-str))
-
-(def double-quote-shell-string
-  (p/semantics (p/conc double-quote
-                       (p/rep* (p/alt non-double-quote-or-backslash doublequote-escaped-chars))
-                       double-quote)
                flatten-apply-str))
 
 (def number-lit


### PR DESCRIPTION
This fixes #129. Check the new regression test case for details.
