### PR TITLE
Improve error messages produced when a shell command fails

### DIFF
--- a/src/drake/shell.clj
+++ b/src/drake/shell.clj
@@ -81,13 +81,12 @@
 
    Loosely based on clojure.java.shell/sh."
   [& args]
-  (let [[cmd raw-opts] (split-with string? args)
-        opts (apply hash-map raw-opts)
-        {:keys [out err die use-shell no-stdin]} opts
+  (let [[cmd {:keys [out err die use-shell no-stdin env replace-env] :as opts}]
+        (split-with string? args)
         windows? (.startsWith (System/getProperty "os.name") "Win")
-        env (as-env-strings (if (:replace-env opts)
-                              (:env opts)
-                              (merge (into {} (System/getenv)) (:env opts))))
+        env (as-env-strings (if replace-env
+                              env
+                              (merge (into {} (System/getenv)) env)))
         cmd-for-exec ^"[Ljava.lang.String;"
                      (into-array (if-not use-shell
                                    cmd


### PR DESCRIPTION
Slingshot was printing the entire lexical context, which contains the user's entire shell environment at least three times. This is so much noise that problems were un-debuggable. I've changed it to not include the local context, by using raw `ex-info` instead of slingshot to throw; I also include the shell script that failed in the output. Should help for things like #116.
