### PR TITLE
fix README to reference public respository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Following are instructions for building from source. Drake is a Clojure project,
 #### Clone the project:
 
 ```bash
-$ git clone git@github.com:Factual/drake.git
+$ git clone https://github.com/Factual/drake.git
 $ cd drake
 ```
 


### PR DESCRIPTION
As it stands, the README file has the private git repository URL. I think most people who chose to build from source are aware of this frequently made mistake; but, for those who are not, it is enough of a source of friction to deter use.
