### PR TITLE
clj-frontend enhancement: Allow step and method to accept variables

### DIFF
--- a/demos/clj-frontend/src/clj_frontend/demo.clj
+++ b/demos/clj-frontend/src/clj_frontend/demo.clj
@@ -53,7 +53,16 @@
     ;; $[XXX] substitution is allowed in commands.
     ["echo \"This is the third output.\" > $OUTPUT"
      "echo \"test_var is set to $test_var - $[test_var].\" >> $OUTPUT"
-     "echo \"The file $INPUT contains:\" | cat - $INPUT >> $[OUTPUT]"])))
+     "echo \"The file $INPUT contains:\" | cat - $INPUT >> $[OUTPUT]"])
+   (cmd-step
+    ["output"]
+    []
+    ["echo $MSG > $OUTPUT"]
+    ;; Variables can be defined inline as key value pairs with strings
+    ;; for keys
+    "MSG" "My Message"
+    ;; While options are key value pairs with keywords for keys
+    :timecheck false)))
 
 ;; (run-workflow advanced-workflow :preview true)
 ;; (run-workflow advanced-workflow)

--- a/test/drake/test/clj_frontend_test.clj
+++ b/test/drake/test/clj_frontend_test.clj
@@ -86,6 +86,35 @@
 out <- in
   cat $[INPUT] > $OUTPUT"))))
 
+(deftest step-vars-test
+  (is (=
+       (step (new-workflow {})
+             ["test-out"]
+             []
+             ["echo \"$var_content\" > $OUTPUT"]
+             "test_variable" "test variable content")
+       {:steps
+        [{:cmds ['(\e \c \h \o \space
+                  \" \$ \v \a \r \_ \c \o \n \t \e \n \t \"
+                  \space \> \space \$ \O \U \T \P \U \T)],
+          :inputs (),
+          :input-tags (),
+          :raw-outputs ["test-out"],
+          :outputs '("test-out"),
+          :output-tags (),
+          :vars
+          {"INPUTN" "*placeholder*",
+           "INPUTS" "*placeholder*",
+           "INPUT" "*placeholder*",
+           "OUTPUT0" "*placeholder*",
+           "OUTPUT" "*placeholder*",
+           "OUTPUTS" "*placeholder*",
+           "OUTPUTN" "*placeholder*",
+           "test_variable" "test variable content"},
+          :opts {}}],
+        :methods {},
+        :vars {}})))
+
 (deftest subsitution-in-file-test
   (is (=
        (-> (new-workflow {})
@@ -130,6 +159,23 @@ sort_and_unique() [shell my_option:my_value]
 
 output1 <- input1 [method:sort_and_unique]
 output2 <- input2 [method:sort_and_unique my_option:new_my_value]")))))
+
+(deftest method-vars-test
+  (is (=
+       (method
+        (new-workflow {})
+        "test"
+        ["echo test $test_var"]
+        "test_var" "test_value")
+       {:steps [],
+        :methods
+        {"test"
+         {:opts {},
+          :vars {"test_var" "test_value"},
+          :cmds ['(\e \c \h \o \space
+                  \t \e \s \t \space
+                  \$ \t \e \s \t \_ \v \a \r)]}},
+        :vars {}})))
 
 (deftest template-test
   (is (=


### PR DESCRIPTION
In case you are interested, this is an enhancement to clj-frontend that I've found useful.  It allows me to specify variables on a step by step basis.

Adds the ability for the step and method functions to accept variables
inline as part of their function call.  Variables can now be specified
as pairs of strings.  This differentiates variables from options which
are now assumed to be specified by keyword value pairs.  This commit
also adds two tests to test this new behaviour of the step and method
functions.

e.g.
(cmd-step
    (new-workflow)
    ["output"]
    []
    ["echo $MSG > $OUTPUT"]
    ;; Variables can be defined inline as key value pairs with strings
    ;; for keys
    "MSG" "My Message"
    ;; While options are key value pairs with keywords for keys
    :timecheck false)
