### PR TITLE
Fix typo in default targetv in clj-frontend/run-workflow

### DIFF
--- a/src/drake/clj_frontend.clj
+++ b/src/drake/clj_frontend.clj
@@ -150,12 +150,12 @@
 
 (defn run-workflow
   "Run the workflow in w-flow.  Optionally specify targetv as a
-  key value pair, e.g. :targetv [\"=...\"]\", otherwise the default
-  targetv is [\"=...\"]\".  Other run options to run-workflow can also
+  key value pair, e.g. :targetv [\"...\"]\", otherwise the default
+  targetv is [\"...\"]\".  Other run options to run-workflow can also
   be specified as key value pairs.  Set :repl-feedback to :quiet,
   :default or :verbose to adjust the repl feedback level."
   [w-flow & {:keys [targetv repl-feedback]
-                 :or {targetv ["=..."]
+                 :or {targetv ["..."]
                       repl-feedback :default}
                  :as run-options}]
   (let [opts (merge d-opts/DEFAULT-OPTIONS


### PR DESCRIPTION
Switches the default targetv from ["=..."] to ["..."] in clj-frontend/run-workflow.
