### PR TITLE
Quick Fix for #153

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml
 .classpath
 .project
 drake.log
+.nrepl*

--- a/src/drake/fs.clj
+++ b/src/drake/fs.clj
@@ -19,15 +19,15 @@
 (defn split-path
   "Returns a tuple: prefix (possibly empty) and path."
   [path]
-  (let [splt (split path #":" -1)]
+  (let [splt (split path #"://" -1)]
     (if (= (count splt) 1)
       ["file" (first splt)]
-      [(first splt) (join ":" (rest splt))])))
+      [(first splt) (join "://" (rest splt))])))
 
 (defn make-path
   "The reverse of split-path"
   [prefix path]
-  (str prefix (when (seq prefix) ":") path))
+  (str prefix (when (seq prefix) "://") path))
 
 (defn path-fs
   "Returns path's filesystem prefix (or an empty string if not specified)."


### PR DESCRIPTION
In the spirit of fixing, rather than whinging, this is a quick fix for my issue #153.  Splitting paths on `:` in `drake.fs$split-path` returns `('C', '\\data\\test.csv')` for properly formed windows paths.  This causes `drake.fs$get-fs` to return `[fs, 'C', '\\data\\test.csv]`.  So, a basic function e.g. `(fs di/data-in? "C:\\data\\test.csv")` goes to `(di/data-in? fs '\\data\\test.csv')` which clearly breaks for windows.  

Splitting on "://" should still get the correct prefixes for e.g. s3://bucket.blah or hdfs://... without mangling the windows paths.  

Note: It seems like there may be a different (and possibly cleaner?) solution to this using make-path more liberally, but it wasn't clear to me exactly where to use that, and this worked.  Hence, the quick-fix appellation.
