### PR TITLE
Feature/inherit context

### DIFF
--- a/src/drake/fs.clj
+++ b/src/drake/fs.clj
@@ -52,6 +52,11 @@
   [path]
   (second (split-path path)))
 
+(defn absolute-path?
+  "Check if given path is absolute"
+  [path]
+  (.isAbsolute (File. (path-filename path))))
+
 (defn should-ignore? [path]
   (drake-ignore (last (split path #"/"))))
 

--- a/src/drake/parser.clj
+++ b/src/drake/parser.clj
@@ -671,12 +671,20 @@
                (throw+ {:msg (str "protocol " protocol " not supported with %context")}))))
          steps)))
 
+(defn- set-step-exec-dir
+  "Set exec dir for step if unset. Steps from nested files
+   may already have exec dirs, do not override"
+  [exec-dir step]
+  (assoc step :exec-dir
+         (or (:exec-dir step)
+             exec-dir)))
+
 (defn- postprocess-context
   [prod file-path]
-  (let [exec-dir (dfs/get-directory-path file-path)]
+  (let [exec-dir (dfs/get-directory-path file-path)
+        set-exec-dir (partial set-step-exec-dir exec-dir)]
     (check-context-incompatible-protocols (:steps prod))
-    (update-in prod [:steps]
-               (partial mapv #(assoc % :exec-dir exec-dir)))))
+    (update-in prod [:steps] (partial mapv set-exec-dir))))
 
 (def ^:const ^:private directive-include "include")
 (def ^:const ^:private directive-call "call")


### PR DESCRIPTION
Nested includes within files included via `%context` use relative paths. #204 

E.g.

foo.d

```
%context nested/bar.d
```

nested/bar.d

```
%include baz.d
```

Now `bar.d` looks in the `nested/` folder for `baz.d` instead of the top level folder.
