### PR TITLE
Use `hadoop classpath` to set HADOOP_CLASSPATH even if HADOOP_CLASSPA…

### DIFF
--- a/bin/drake
+++ b/bin/drake
@@ -42,11 +42,9 @@ fi
 # Tries to include local hadoop library on classpath for HDFS support.
 # If Hadoop client is not installed locally, defaults to built-in hadoop version.
 # If you don't need HDFS support with your Drake workflows, none of this matters.
-if [ -z ${HADOOP_CLASSPATH:+x} ]; then
-  if [[ `which hadoop` ]]; then
-    HADOOP_CLASSPATH=`hadoop classpath 2>/dev/null`
-    HADOOP_VERSION=`hadoop version | head -1`
-  fi
+if [[ `which hadoop` ]]; then
+  HADOOP_CLASSPATH=`hadoop classpath 2>/dev/null`
+  HADOOP_VERSION=`hadoop version | head -1`
 fi
 
 if [ "$1" = "--hadoop-version" ]; then


### PR DESCRIPTION
@dirtyvagabond 

For https://github.com/Factual/drake/issues/213

Tested with:
-  `lein test`
- Running a workflow requiring HDFS reads in an environment with no HADOOP_CLASSPATH set
- Running a workflow requiring HDFS reads in an environment with a partial HADOOP_CLASSPATH set (the previously breaking case)
- Running a basic workflow not requiring HDFS in an environment without a local hadoop binary
